### PR TITLE
Add viewcount to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,6 @@ You should never use this middleware in production — use nginx for serving
 pre-built bundles to a browser.
 
 [browserify]: http://browserify.org
+
+
+![viewcount](https://viewcount.jepso.com/count/andreypopp/connect-browserify.png)


### PR DESCRIPTION
I thought this might be interesting as an experiment to get the 3 (that I'm aware of so far) browserify middleware repos on viewcount.

Once it has at least one view you can see how many views it has by going to https://viewcount.jepso.com/andreypopp/connect-browserify

_Disclaimer:_ I run viewcount and put mine on there a few hours ago, so have about a 50 view head start.

P.S. If you login at https://viewcount.jepso.com/ then it won't count your own views.
