### PR TITLE
Handle build errors more neatly

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ app.use('/js/app.js', browserify({
       .pipe(uglifyStream);        // Must return another stream
   },
 
+  onError: function(err) {        // optional, called if errors occur during the
+    console.warn(err);            // build process. If not set, errors are only
+  },                              // available via the middleware response
+
   contentType: 'text/javascript', // optional, Content-type header to use, by
                                   // default this equals to 'application/javascript'
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function serve(options, maybeOptions) {
 
   var contentType = options.contentType || 'application/javascript';
   var pipes = options.pipes || function(x) { return x; };
+  var onError = options.onError || function() { };
 
   if (isBrowserify(options)) {
     b = options;
@@ -53,6 +54,7 @@ function serve(options, maybeOptions) {
       output.on('error', reject);
       output.pipe(concat({encoding: 'string'}, resolve));
     });
+    rendered.catch(onError);
   }
 
   make();

--- a/specs/fixtures/broken.js
+++ b/specs/fixtures/broken.js
@@ -1,0 +1,1 @@
+var dep = require('


### PR DESCRIPTION
I ran into a couple of issues with the error handling, the problem is that if the build completes before a request is made, the promise is resolved without an error catcher.

A small fix, but in order to reproduce in the test, I had to juggle around a little bit.

Since I was attaching an error handler to the promise, I figured it might as well exposed to the public api.
