### PR TITLE
Updating browserify to 14.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "bluebird": "^2.9.0",
-    "browserify": "^9.0.0",
+    "browserify": "^14.0.0",
     "watchify": "^3.0.0",
     "concat-stream": "^1.4.6"
   },


### PR DESCRIPTION
Updating to `browserify@14.4.0` to fix some NSP vulnerability warnings:

```
(+) 2 vulnerabilities found
 Name          Installed   Patched   Path                                                                          More Info
 minimatch     2.0.10      >=3.0.2   connect-browserify@4.0.0 > browserify@9.0.8 > glob@4.5.3 > minimatch@2.0.10   https://nodesecurity.io/advisories/118
 shell-quote   0.0.1       >=1.6.1   connect-browserify@4.0.0 > browserify@9.0.8 > shell-quote@0.0.1               https://nodesecurity.io/advisories/117
```